### PR TITLE
[FIX] JsonPostRequest not post json data

### DIFF
--- a/src/Http/JsonPostRequest.php
+++ b/src/Http/JsonPostRequest.php
@@ -19,6 +19,14 @@ class JsonPostRequest extends HttpPostRequest
     }
 
     /**
+     * @return string
+     */
+    public function getPostFields()
+    {
+        return json_encode($this->post_fields, JSON_FORCE_OBJECT);
+    }
+
+    /**
      * @return array
      */
     public function getData()


### PR DESCRIPTION
## Abstract
JsonPostRequest class not post json data, http_build_query used in parent class.

すみません、日本語で。
クラス名からjson_encodeをpost_fieldとして送るのが適当かと思い、PRを出させていただきました。
（phitflyer側で正常に動作していなかったため、こちらに修正してローカルにて使用しております）

意図と違うようでしたら無視していただければと思います。